### PR TITLE
Dynamic allocation of Device based on the input's device to account for DDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ At the moment we aren't seeing a significant improvement in the performance of t
 # Installation
 ```bash
 git clone git@github.com/AntonioTepsich/ckan.git
-cd ckan
+cd Convolutional-KANs
 pip install -r requirements.txt
 ```
 # Usage

--- a/kan_convolutional/KANConv.py
+++ b/kan_convolutional/KANConv.py
@@ -48,7 +48,7 @@ class KAN_Convolutional_Layer(torch.nn.Module):
         self.grid_size = grid_size
         self.spline_order = spline_order
         self.kernel_size = kernel_size
-        self.device = device
+        # self.device = device
         self.dilation = dilation
         self.padding = padding
         self.convs = torch.nn.ModuleList()
@@ -72,12 +72,13 @@ class KAN_Convolutional_Layer(torch.nn.Module):
                     base_activation=base_activation,
                     grid_eps=grid_eps,
                     grid_range=grid_range,
-                    device = device
+                    # device = device ## changed device to be allocated as per the input device for pytorch DDP
                 )
             )
 
     def forward(self, x: torch.Tensor, update_grid=False):
         # If there are multiple convolutions, apply them all
+        self.device = x.device
         if self.n_convs>1:
             return convolution.multiple_convs_kan_conv2d(x, self.convs,self.kernel_size[0],self.stride,self.dilation,self.padding,self.device)
         
@@ -112,7 +113,7 @@ class KAN_Convolution(torch.nn.Module):
         self.stride = stride
         self.padding = padding
         self.dilation = dilation
-        self.device = device
+        # self.device = device
         self.conv = KANLinear(
             in_features = math.prod(kernel_size),
             out_features = 1,
@@ -127,6 +128,7 @@ class KAN_Convolution(torch.nn.Module):
         )
 
     def forward(self, x: torch.Tensor, update_grid=False):
+        self.device = x.device
         return convolution.kan_conv2d(x, self.conv,self.kernel_size[0],self.stride,self.dilation,self.padding,self.device)
     
     def regularization_loss(self, regularize_activation=1.0, regularize_entropy=1.0):


### PR DESCRIPTION
Hello,

The pytorch's Distributed Data Parallel library is an important tool to run a model with distributed data parallelism across multiple GPUs. The technique requires the device of the model to be allocated dynamically by the DDP class, which would make multiple copies of models and store it in multiple gpu( cuda:0, cuda:1, etc). 

Directly setting up the device in the layer blocks the ability to use this feature. I made sure that there is no need to initialize the device parameter while making the KAN layer and that it would be based off of the input's device (which works because in DDP the inputs are also distributed across the gpu ids 0,1,2, etc.

I tested this on my case and it works well, and doesn't break the existing way of specifying the device either.

Without this fix, the KANConvolution doesn't work with data parallel because the inputs would be in different gpus and the model would have some of its layers (the KANCNN) fixated into one. 

